### PR TITLE
Rename `todoColumn` to `readyColumn` for Kanban consistency

### DIFF
--- a/.pi/extensions/github-orchestrator/src/index.ts
+++ b/.pi/extensions/github-orchestrator/src/index.ts
@@ -18,7 +18,7 @@ interface Config {
   repo: string;
   projectNumber: number;
   backlogColumn: string;
-  todoColumn: string;
+  readyColumn: string;
   inProgressColumn: string;
   inReviewColumn: string;
   doneColumn: string;
@@ -58,7 +58,7 @@ function loadConfig(cwd: string): Config {
   if (!cfg.projectNumber) throw new Error(`githubOrchestrator.projectNumber is required`);
   return {
     backlogColumn: "Backlog",
-    todoColumn: "Ready",
+    readyColumn: "Ready",
     inProgressColumn: "In Progress",
     inReviewColumn: "In Review",
     doneColumn: "Done",
@@ -493,7 +493,7 @@ export default async function (pi: ExtensionAPI) {
     description: "Fan out worker agents for all issues in the Ready column",
     handler: async (_args, ctx) => {
       await init();
-      const readyColumn = cfg.todoColumn;
+      const readyColumn = cfg.readyColumn;
       let issues = await listIssues(gql, cfg, readyColumn);
       // Filter out issues labelled 'human' — those are reserved for human implementation
       const humanCount = issues.filter((i) => i.labels.includes("human")).length;

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -4,7 +4,7 @@
     "repo": "github-issue-orchestrator",
     "projectNumber": 3,
     "backlogColumn": "Backlog",
-    "todoColumn": "Ready",
+    "readyColumn": "Ready",
     "inProgressColumn": "In progress",
     "inReviewColumn": "In review",
     "doneColumn": "Done",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Users can edit these `.md` files freely; changes take effect on the next `/reloa
     "repo": "my-repo",
     "projectNumber": 1,
     "backlogColumn": "Backlog",
-    "todoColumn": "Ready",
+    "readyColumn": "Ready",
     "inProgressColumn": "In Progress",
     "inReviewColumn": "In Review",
     "doneColumn": "Done",
@@ -87,7 +87,7 @@ Users can edit these `.md` files freely; changes take effect on the next `/reloa
 }
 ```
 
-Only `owner`, `repo`, and `projectNumber` are required; all other fields have defaults matching the above. `todoColumn` is the column the planner moves issues into and `/dispatch` reads from (defaults to `"Ready"`).
+Only `owner`, `repo`, and `projectNumber` are required; all other fields have defaults matching the above. `readyColumn` is the column the planner moves issues into and `/dispatch` reads from (defaults to `"Ready"`).
 
 ## Typical workflow
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Edit `.pi/settings.json` in your project:
     "repo": "my-repo",
     "projectNumber": 1,
     "backlogColumn": "Backlog",
-    "todoColumn": "Ready",
+    "readyColumn": "Ready",
     "inProgressColumn": "In Progress",
     "inReviewColumn": "In Review",
     "doneColumn": "Done",
@@ -64,7 +64,7 @@ Edit `.pi/settings.json` in your project:
 }
 ```
 
-Only `owner`, `repo`, and `projectNumber` are required. All other fields default to the values shown above. The `todoColumn` is where the planner deposits issues for human review before dispatch — make sure this column exists in your GitHub Project.
+Only `owner`, `repo`, and `projectNumber` are required. All other fields default to the values shown above. The `readyColumn` is where the planner deposits issues for human review before dispatch — make sure this column exists in your GitHub Project.
 
 ## Commands
 


### PR DESCRIPTION
Rename `todoColumn` to `readyColumn` across the codebase to align with the GitHub Kanban Issues template column naming. The default value remains `"Ready"` — only the setting name changes for clarity and consistency.

**Changes:**
- `src/index.ts`: Renamed `todoColumn` → `readyColumn` in `Config` interface, defaults object, and `cfg.todoColumn` reference in the `dispatch` command handler
- `.pi/settings.json`: Renamed `todoColumn` → `readyColumn` key
- `AGENTS.md`: Updated config example and documentation reference
- `README.md`: Updated config example and documentation reference

Closes #7