### PR TITLE
Enforce mandatory code reviews

### DIFF
--- a/.pi/agents/reviewer.md
+++ b/.pi/agents/reviewer.md
@@ -1,29 +1,31 @@
 ---
 name: reviewer
-description: Reviews a PR diff against the issue description and posts an APPROVE or REVISE verdict.
+description: Reviews a PR diff against the issue description and posts an APPROVE or REVISE verdict as a PR review.
 worktree: true
 inheritProjectContext: true
 ---
 
-You are a reviewer agent. Your job is to evaluate a pull request against its linked issue and post a clear verdict.
+You are a reviewer agent. Your job is to evaluate a pull request against its linked issue and post a clear verdict as a PR review.
 
 ## Task
 
 You will receive either:
-- A PR number to review, or
-- Context from a previous chain step (worker output) containing the PR URL and issue number
+- A PR number to review directly, or
+- Context from a previous chain step (worker output) containing a line like `Created PR #N: <url>` — extract the PR number `N` from this output
+
+If you cannot determine a PR number (e.g., you are reviewing a plan, not code), fall back to posting on the issue using `gh_add_comment` instead.
 
 ## Steps
 
-1. **Read the issue** — use `gh_add_comment` context or fetch the issue to understand what was required.
+1. **Read the issue** — fetch the linked issue to understand what was required. You can use `gh_add_comment` context or look up the issue details.
 
-2. **Inspect the diff** — use bash to examine what changed:
+2. **Inspect the diff** — extract the PR number from the task context (previous chain step output or direct input), then:
    ```bash
-   git diff main...HEAD
+   gh pr diff <PR_NUMBER>
    ```
    Also check commit messages:
    ```bash
-   git log main..HEAD --oneline
+   gh pr view <PR_NUMBER> --json commits --jq '.commits[].messageHeadline'
    ```
 
 3. **Evaluate** the changes against these criteria:
@@ -32,22 +34,27 @@ You will receive either:
    - **Code quality**: Are changes well-structured and consistent with existing patterns?
    - **Tests**: Are tests added or updated where appropriate?
 
-4. **Post a verdict** using `gh_add_comment` on the issue:
+4. **Post a verdict** using `gh_create_pr_review` on the pull request:
 
    For approval:
-   ```
-   ## Review: APPROVE ✅
-   <brief summary of what was reviewed and why it passes>
-   ```
+   - `event`: "APPROVE"
+   - `body`:
+     ```
+     ## Review: APPROVE ✅
+     <brief summary of what was reviewed and why it passes>
+     ```
 
    For revision requests:
-   ```
-   ## Review: REVISE 🔄
-   <specific, actionable list of required changes>
-   ```
+   - `event`: "REQUEST_CHANGES"
+   - `body`:
+     ```
+     ## Review: REVISE 🔄
+     <specific, actionable list of required changes>
+     ```
 
 ## Rules
 
 - Be specific in REVISE feedback — vague comments are not actionable.
 - Only APPROVE when all criteria are met. When in doubt, request a revision.
 - Do not make code changes yourself — review only.
+- Always extract the PR number carefully from the `Created PR #N:` output format to avoid posting on the wrong PR.

--- a/.pi/extensions/github-orchestrator/src/index.ts
+++ b/.pi/extensions/github-orchestrator/src/index.ts
@@ -386,9 +386,9 @@ export default async function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "gh_add_comment",
     label: "Add GitHub Comment",
-    description: "Post a comment on an issue",
+    description: "Post a comment on an issue or pull request",
     parameters: Type.Object({
-      issueNumber: Type.Number({ description: "Issue number" }),
+      issueNumber: Type.Number({ description: "Issue or pull request number" }),
       body: Type.String({ description: "Comment text (markdown supported)" }),
     }),
     async execute(_id, params, _signal, _onUpdate, _ctx) {
@@ -400,6 +400,36 @@ export default async function (pi: ExtensionAPI) {
         body: params.body,
       });
       return { content: [{ type: "text", text: `Comment posted: ${comment.html_url}` }], details: {} };
+    },
+  });
+
+  pi.registerTool({
+    name: "gh_create_pr_review",
+    label: "Create GitHub PR Review",
+    description: "Submit a review on a pull request with an APPROVE, REQUEST_CHANGES, or COMMENT verdict",
+    parameters: Type.Object({
+      prNumber: Type.Number({ description: "Pull request number" }),
+      body: Type.String({ description: "Review body text (markdown supported)" }),
+      event: Type.Union([
+        Type.Literal("APPROVE"),
+        Type.Literal("REQUEST_CHANGES"),
+        Type.Literal("COMMENT"),
+      ], { description: "Review verdict: APPROVE, REQUEST_CHANGES, or COMMENT" }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, _ctx) {
+      await init();
+      const validEvents = ["APPROVE", "REQUEST_CHANGES", "COMMENT"] as const;
+      if (!validEvents.includes(params.event)) {
+        throw new Error(`Invalid review event "${params.event}". Must be APPROVE, REQUEST_CHANGES, or COMMENT.`);
+      }
+      const { data: review } = await octokit.pulls.createReview({
+        owner: cfg.owner,
+        repo: cfg.repo,
+        pull_number: params.prNumber,
+        body: params.body,
+        event: params.event,
+      });
+      return { content: [{ type: "text", text: `Review submitted on PR #${params.prNumber}: ${review.html_url}` }], details: {} };
     },
   });
 
@@ -511,7 +541,7 @@ export default async function (pi: ExtensionAPI) {
       }
       const tasks = capped.map((issue) => {
         const task = escapeForPiArg(`implement #${issue.number}: ${issue.title}\n${issue.body}`);
-        return `worker[worktree=true] "${task}"`;
+        return `implement[worktree=true] "${task}"`;
       });
       const cmd = `/parallel ${tasks.join(" -> ")}`;
       await pi.sendUserMessage(cmd, { deliverAs: "followUp" });


### PR DESCRIPTION
This PR enforces mandatory code reviews by ensuring every dispatched worker is followed by an automated reviewer.

### Changes

**New tool: `gh_create_pr_review`** (`.pi/extensions/github-orchestrator/src/index.ts`)
- Submits a proper GitHub PR review with `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` event
- Integrates with GitHub's review UI and branch protection rules
- Uses `octokit.pulls.createReview` under the hood

**Updated `gh_add_comment` description** (`.pi/extensions/github-orchestrator/src/index.ts`)
- Description changed from "Post a comment on an issue" to "Post a comment on an issue or pull request"
- Parameter description changed from "Issue number" to "Issue or pull request number"
- No logic change — `octokit.issues.createComment` already works for PRs

**`/dispatch` now uses `implement` chain** (`.pi/extensions/github-orchestrator/src/index.ts`)
- Changed agent from `worker[worktree=true]` to `implement[worktree=true]`
- This runs worker → reviewer pipeline for every dispatched issue

**Updated `reviewer.md`** (`.pi/agents/reviewer.md`)
- Posts verdicts as PR reviews via `gh_create_pr_review` (not issue comments via `gh_add_comment`)
- Uses `gh pr diff <PR_NUMBER>` instead of `git diff main...HEAD` for reliable diff fetching across worktrees
- Clarifies how to extract PR number from chain context (`Created PR #N:` format)
- Adds fallback for plan reviews (triage chain) using `gh_add_comment` when no PR exists

Closes #6